### PR TITLE
mobile view for reader

### DIFF
--- a/src/app/reader/[id]/page.tsx
+++ b/src/app/reader/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useBookZipStore } from "@/store/bookZipStore";
 import { loadZip } from "@/utils/zipUtils";
 import { useEffect } from "react";
 import React from "react";
+import { useBreakpoints } from "@/hooks/useBreakpoints";
 
 export default function ReaderPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = React.use(params);
@@ -33,10 +34,14 @@ export default function ReaderPage({ params }: { params: Promise<{ id: string }>
     return () => worker.terminate();
   }, [id, setBookInfo, setBookZip]);
 
+  const { isMobile } = useBreakpoints();
+
+  const isSingleMode = isMobile || rendererMode === "single";
+
   return (
     <>
       {bookInfo.name ? (
-        rendererMode === "single" ? (
+        isSingleMode ? (
           <SingleColumnRenderer />
         ) : (
           <DoubleColumnRenderer />

--- a/src/components/Renderer/SingleColumnRenderer.tsx
+++ b/src/components/Renderer/SingleColumnRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@nextui-org/button";
 import { useBookInfoStore } from "@/store/bookInfoStore";
 import { useCurrentChapterStore } from "@/store/currentChapterStore";
@@ -13,24 +13,35 @@ import { useRendererModeStore } from "@/store/rendererModeStore";
 import { loadChapterContent } from "@/utils/chapterLoader";
 import { useBookZipStore } from "@/store/bookZipStore";
 import { parseAndProcessChapter } from "@/utils/chapterParser";
-import { waitForImagesAndCalculatePages, writeToIframe } from "@/utils/iframeHandler";
+import {
+  waitForImagesAndCalculatePages,
+  writeToIframe,
+} from "@/utils/iframeHandler";
 import { useTranslations } from "next-intl";
 import { useDisclosure } from "@nextui-org/modal";
 import _ from "lodash";
 import { useKeyboardNavigation } from "@/hooks/useKeyboardNavigation";
 import { useRouter } from "next/navigation";
 import { BookInfoModal } from "@/components/BookInfoModal";
+import { MoreButton } from "./Toolbar/MoreButton";
 
 const EpubReader: React.FC = () => {
   const t = useTranslations("SingleColumnRenderer");
-  const currentChapter = useCurrentChapterStore((state) => state.currentChapter);
-  const setCurrentChapter = useCurrentChapterStore((state) => state.setCurrentChapter);
-  const currentFontConfig = useRendererConfigStore((state) => state.rendererConfig);
+  const currentChapter = useCurrentChapterStore(
+    (state) => state.currentChapter
+  );
+  const setCurrentChapter = useCurrentChapterStore(
+    (state) => state.setCurrentChapter
+  );
+  const currentFontConfig = useRendererConfigStore(
+    (state) => state.rendererConfig
+  );
   const bookInfo = useBookInfoStore((state) => state.bookInfo);
   const { theme } = useTheme();
   const bookZip = useBookZipStore((state) => state.bookZip);
   const rendererMode = useRendererModeStore((state) => state.rendererMode);
   const router = useRouter();
+  const [isToolbarExpanded, setIsToolbarExpanded] = useState(false);
 
   useEffect(() => {
     const processChapter = async () => {
@@ -39,10 +50,21 @@ const EpubReader: React.FC = () => {
         bookInfo,
         currentChapter
       );
-      const updatedChapter = await parseAndProcessChapter(chapterContent, bookZip, basePath);
-      const renderer = writeToIframe(updatedChapter, currentFontConfig, theme, rendererMode, 0);
+      const updatedChapter = await parseAndProcessChapter(
+        chapterContent,
+        bookZip,
+        basePath
+      );
+      const renderer = writeToIframe(
+        updatedChapter,
+        currentFontConfig,
+        theme,
+        rendererMode,
+        0
+      );
       const iframeDoc =
-        renderer.contentDocument || (renderer.contentWindow && renderer.contentWindow.document);
+        renderer.contentDocument ||
+        (renderer.contentWindow && renderer.contentWindow.document);
       if (iframeDoc) {
         waitForImagesAndCalculatePages(renderer, iframeDoc);
       } else {
@@ -58,7 +80,9 @@ const EpubReader: React.FC = () => {
   }, [bookInfo, bookZip, currentChapter]);
 
   useEffect(() => {
-    const renderer = document.getElementById("epub-renderer") as HTMLIFrameElement;
+    const renderer = document.getElementById(
+      "epub-renderer"
+    ) as HTMLIFrameElement;
     if (!renderer || !renderer.contentWindow) {
       throw new Error("Renderer not found");
     }
@@ -113,7 +137,7 @@ const EpubReader: React.FC = () => {
   return (
     <>
       <div className="w-full h-screen bg-gray-100 flex justify-center fixed z-0 dark:bg-neutral-800"></div>
-      <div className="w-1/2 h-14 bg-white border-b-2 flex fixed items-center pl-4 z-20 inset-x-0 m-auto dark:bg-neutral-900">
+      <div className="sm:w-1/2 h-14 bg-white border-b-2 flex fixed items-center pl-4 z-20 inset-x-0 m-auto dark:bg-neutral-900">
         <div className="flex w-full justify-between items-center pr-4">
           <div className="flex items-center cursor-pointer" onClick={onOpen}>
             <BookOpen size={20} />
@@ -122,10 +146,12 @@ const EpubReader: React.FC = () => {
                 bookInfo.language === "zh" ? "" : "italic"
               }`}
             >
-              {bookInfo.language === "zh" ? `《${bookInfo.name}》` : bookInfo.name}
+              {bookInfo.language === "zh"
+                ? `《${bookInfo.name}》`
+                : bookInfo.name}
             </p>
           </div>
-          <div>
+          <div className="flex items-center">
             <Button
               className="ml-4 bg-white dark:bg-neutral-900"
               isIconOnly
@@ -135,11 +161,16 @@ const EpubReader: React.FC = () => {
             >
               <House size={16} className="dark:bg-neutral-900" />
             </Button>
+            
+            <MoreButton />
           </div>
         </div>
       </div>
-      <div className="w-1/2 h-full min-h-[100vh] mx-auto bg-white relative pt-14 flex flex-col dark:bg-neutral-900">
-        <iframe id="epub-renderer" className="w-full z-10 px-14 grow dark:bg-neutral-900"></iframe>
+      <div className="sm:w-1/2 h-full min-h-[100vh] mx-auto bg-white relative pt-14 flex flex-col dark:bg-neutral-900">
+        <iframe
+          id="epub-renderer"
+          className="w-full z-10 px-14 grow dark:bg-neutral-900"
+        ></iframe>
         <div className="w-full z-10 h-20 flex justify-around items-start">
           <Button
             variant="bordered"
@@ -157,8 +188,8 @@ const EpubReader: React.FC = () => {
           </Button>
         </div>
 
-        <div className="fixed right-[20%] bottom-[40%] z-50">
-          <Toolbar />
+        <div className="hidden sm:block fixed right-[20%] bottom-[40%] z-50">
+          <Toolbar/>
         </div>
       </div>
 

--- a/src/components/Renderer/Toolbar/FontConfig.tsx
+++ b/src/components/Renderer/Toolbar/FontConfig.tsx
@@ -6,6 +6,7 @@ import { Slider } from "@nextui-org/slider";
 import { ALargeSmall, AArrowDown, AArrowUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { createPortal } from "react-dom";
 
 const FontConfig: React.FC = ({}) => {
   const t = useTranslations("Renderer");
@@ -42,14 +43,7 @@ const FontConfig: React.FC = ({}) => {
     });
   };
 
-  return (
-    <>
-      <div
-        className="w-12 h-12 mt-4 bg-white rounded-full shadow-md flex items-center justify-center cursor-pointer z-10 dark:bg-neutral-900"
-        onClick={handleMenuClick}
-      >
-        <ALargeSmall />
-      </div>
+  const overlay = <>
       <div
         className={`fixed top-0 left-0 w-screen h-screen bg-black bg-opacity-10 z-20 transition-opacity duration-500 ${
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
@@ -58,7 +52,7 @@ const FontConfig: React.FC = ({}) => {
       ></div>
       <div
         className={`w-auto h-auto p-5 bg-white dark:bg-neutral-800 fixed bottom-[calc(7vh-32px)] ${
-          mode === "single" ? "right-1/4" : "right-[10%]"
+          mode === "single" ? "right-0 sm:right-1/4" : "right-[10%]"
         } z-30 rounded-2xl transition-opacity duration-500 transform ${
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
         } shadow-md`}
@@ -94,6 +88,19 @@ const FontConfig: React.FC = ({}) => {
           ))}
         </div>
       </div>
+  </>
+
+  return (
+    <>
+      <div
+        className="w-12 h-12 mt-4 bg-white rounded-full shadow-md flex items-center justify-center cursor-pointer z-10 dark:bg-neutral-900"
+        onClick={handleMenuClick}
+      >
+        <ALargeSmall />
+      </div>
+      {
+        createPortal(overlay, document.body)
+      }
     </>
   );
 };

--- a/src/components/Renderer/Toolbar/Index.tsx
+++ b/src/components/Renderer/Toolbar/Index.tsx
@@ -7,7 +7,9 @@ export const Toolbar = () => {
   return (
     <>
       <Menu />
-      <SwitchRendererMode />
+      <div className="hidden sm:block">
+        <SwitchRendererMode />
+      </div>
       <ThemeSwitcher />
       <FontConfig />
     </>

--- a/src/components/Renderer/Toolbar/Menu.tsx
+++ b/src/components/Renderer/Toolbar/Menu.tsx
@@ -7,19 +7,26 @@ import { useRendererModeStore } from "@/store/rendererModeStore";
 import { useBookInfoStore } from "@/store/bookInfoStore";
 import { useCurrentChapterStore } from "@/store/currentChapterStore";
 import { useTheme } from "next-themes";
+import { createPortal } from "react-dom";
 
 const Menu: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [coverUrl, setCoverUrl] = useState<string | null>(null);
   const mode = useRendererModeStore((state) => state.rendererMode);
   const bookInfo = useBookInfoStore((state) => state.bookInfo);
-  const currentChapter = useCurrentChapterStore((state) => state.currentChapter);
-  const setCurrentChapter = useCurrentChapterStore((state) => state.setCurrentChapter);
+  const currentChapter = useCurrentChapterStore(
+    (state) => state.currentChapter
+  );
+  const setCurrentChapter = useCurrentChapterStore(
+    (state) => state.setCurrentChapter
+  );
   const { theme } = useTheme();
 
   useEffect(() => {
     if (bookInfo.coverBlob) {
-      const url = URL.createObjectURL(new Blob([bookInfo.coverBlob], { type: "image/jpeg" }));
+      const url = URL.createObjectURL(
+        new Blob([bookInfo.coverBlob], { type: "image/jpeg" })
+      );
       setCoverUrl(url);
 
       return () => {
@@ -36,14 +43,8 @@ const Menu: React.FC = () => {
     setIsOpen(false);
   };
 
-  return (
+  const overlay = (
     <>
-      <div
-        className="w-12 h-12 bg-white rounded-full shadow-md flex items-center justify-center cursor-pointer z-10 dark:bg-neutral-900"
-        onClick={handleMenuClick}
-      >
-        <MenuIcon isOpen={isOpen} />
-      </div>
       <div
         className={`fixed top-0 left-0 w-screen h-screen bg-black bg-opacity-10 z-20 transition-opacity duration-500 ${
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
@@ -51,8 +52,8 @@ const Menu: React.FC = () => {
         onClick={handleOverlayClick}
       ></div>
       <div
-        className={`w-auto max-w-md min-w-96 h-[86vh] bg-white rounded-2xl dark:bg-neutral-800 fixed top-[calc(7vh+32px)] ${
-          mode === "single" ? "right-1/4" : " right-[10%]"
+        className={`max-w-md w-full sm:w-96 h-[86vh] bg-white rounded-2xl dark:bg-neutral-800 fixed top-[calc(7vh+32px)] ${
+          mode === "single" ? "right-0 sm:right-1/4" : " right-[10%]"
         } z-30 transition-opacity duration-500 transform ${
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
         } shadow-md`}
@@ -85,13 +86,17 @@ const Menu: React.FC = () => {
                 <div
                   key={index}
                   className={`py-4 px-8 ${
-                    theme === "dark" ? "hover:bg-neutral-600" : "hover:bg-blue-50"
+                    theme === "dark"
+                      ? "hover:bg-neutral-600"
+                      : "hover:bg-blue-50"
                   }  dark:text-white cursor-pointer	`}
                 >
                   <a
                     onClick={() => setCurrentChapter(index)}
                     className={`block text-sm ${
-                      currentChapter === index ? "text-blue-500" : "text-slate-500 dark:text-white"
+                      currentChapter === index
+                        ? "text-blue-500"
+                        : "text-slate-500 dark:text-white"
                     }`}
                   >
                     {_item.text}
@@ -102,6 +107,18 @@ const Menu: React.FC = () => {
           </ScrollArea>
         </div>
       </div>
+    </>
+  );
+
+  return (
+    <>
+      <div
+        className="w-12 h-12 bg-white rounded-full shadow-md flex items-center justify-center cursor-pointer z-10 dark:bg-neutral-900"
+        onClick={handleMenuClick}
+      >
+        <MenuIcon isOpen={isOpen} />
+      </div>
+      {createPortal(overlay, document.body)}
     </>
   );
 };

--- a/src/components/Renderer/Toolbar/MoreButton.tsx
+++ b/src/components/Renderer/Toolbar/MoreButton.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@nextui-org/button";
+import { MoreVertical } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Toolbar } from "./Index";
+
+export const MoreButton = () => {
+  const [isToolbarExpanded, setIsToolbarExpanded] = useState(false);
+
+  // click outside to close
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+
+      if (isToolbarExpanded) {
+        setIsToolbarExpanded(false);
+        return false;
+      }
+
+      return true;
+    };
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [isToolbarExpanded]);
+
+  return (
+    <div className="sm:hidden">
+      <Button
+        className="more-button ml-2 bg-white dark:bg-neutral-900"
+        isIconOnly
+        variant="bordered"
+        radius="sm"
+        onClick={() => setIsToolbarExpanded(!isToolbarExpanded)}
+      >
+        <MoreVertical size={16} className="dark:bg-neutral-900" />
+      </Button>
+      <div className={"absolute top-full bg-white dark:bg-neutral-900 " + (isToolbarExpanded ? "block" : "hidden")}>
+        <Toolbar />
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useBreakpoints.ts
+++ b/src/hooks/useBreakpoints.ts
@@ -1,0 +1,15 @@
+import { MOBILE_BREAKPOINT } from "@/utils/const";
+import { useEffect, useState } from "react";
+
+export const useBreakpoints = () => {
+  const [isMobile, setIsMobile] = useState(window?.innerWidth < 640);
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window?.innerWidth < MOBILE_BREAKPOINT);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  return { isMobile };
+};
+

--- a/src/store/rendererModeStore.ts
+++ b/src/store/rendererModeStore.ts
@@ -1,3 +1,4 @@
+import { MOBILE_BREAKPOINT } from "@/utils/const";
 import { create } from "zustand";
 
 type rendererModeType = "single" | "double";
@@ -8,6 +9,6 @@ type rendererModeStore = {
 };
 
 export const useRendererModeStore = create<rendererModeStore>((set) => ({
-  rendererMode: "double",
+  rendererMode: window?.innerWidth < MOBILE_BREAKPOINT ? "single" : "double",
   setRendererMode: (mode: rendererModeType) => set({ rendererMode: mode }),
 }));

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,0 +1,1 @@
+export const MOBILE_BREAKPOINT = 640;

--- a/src/utils/iframeHandler.ts
+++ b/src/utils/iframeHandler.ts
@@ -21,6 +21,17 @@ export const writeToIframe = (
   
   const script = `
     <script>
+
+      document.addEventListener('click', function(e) {
+        const event = new MouseEvent('click', {
+          ...e,
+          bubbles: true,
+          cancelable: true,
+        });
+        console.log('clicked', event);
+        window.parent.document.dispatchEvent(event);
+      });
+
       document.addEventListener('keydown', function(e) {
         // Create a new event and dispatch it to the parent window
         const event = new KeyboardEvent('keydown', {


### PR DESCRIPTION
Changes:

In mobile view:

1. move toolbar to top
2. modify menu and fontconfig layout
3. default to single view, disable view mode toggle button
4. use `createPortal` to render menu and fontconfig

<img width="546" alt="image" src="https://github.com/user-attachments/assets/fc9ad920-2356-46ce-995a-9003ff75f0ac">

<img width="560" alt="image" src="https://github.com/user-attachments/assets/72569f47-4b95-45d8-8970-4c0b516d5c98">

<img width="555" alt="image" src="https://github.com/user-attachments/assets/e07fa6ef-3397-46f1-a4e3-bba430caa283">
